### PR TITLE
[CNIL] update requirements & cnil's decisions link

### DIFF
--- a/pygdpr/requirements.txt
+++ b/pygdpr/requirements.txt
@@ -11,12 +11,12 @@ docx2txt==0.8
 requests==2.26.0
 beautifulsoup4==4.8.0
 click==8.0.1
-dateparser==1.0.0
+dateparser==1.1.1
 urllib3==1.26.6
 pandas==1.3.3
 matplotlib==3.4.3
 numpy==1.21.2
-scipy==1.7.1
+scipy==1.7.2
 Pillow==8.3.2
 lxml==4.6.3
 setuptools>=57.0.0


### PR DESCRIPTION
Changed the link for CNIL's decisions from https://www.cnil.fr/fr/deliberations to https://www.cnil.fr/fr/les-sanctions-prononcees-par-la-cnil and updated the code so that it adapts to the new format.

Some decisions have links to legifrance, this works same as before. Some don't (the name of the legal entity is not disclosed), and for these ones I had to improvise a little text based on the information on the website. 